### PR TITLE
Ets node info simple endpoint

### DIFF
--- a/src/epl_ets.erl
+++ b/src/epl_ets.erl
@@ -10,7 +10,9 @@
 
 %% API
 -export([start_link/0,
+         subscribe/0,
          subscribe/1,
+         unsubscribe/0,
          unsubscribe/1]).
 
 %% gen_server callbacks
@@ -34,8 +36,14 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+subscribe() ->
+    subscribe(self()).
+
 subscribe(Pid) ->
     gen_server:cast(?MODULE, {subscribe, Pid}).
+
+unsubscribe() ->
+    unsubscribe(self()).
 
 unsubscribe(Pid) ->
     gen_server:cast(?MODULE, {unsubscribe, Pid}).

--- a/src/epl_ets.erl
+++ b/src/epl_ets.erl
@@ -1,0 +1,78 @@
+%%%-------------------------------------------------------------------
+%% @doc epl_ets modules.
+%% It is a gen server listening to messages from epl main application.
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(epl_ets).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         subscribe/1,
+         unsubscribe/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {subscribers = []}).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+subscribe(Pid) ->
+    gen_server:cast(?MODULE, {subscribe, Pid}).
+
+unsubscribe(Pid) ->
+    gen_server:cast(?MODULE, {unsubscribe, Pid}).
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([]) ->
+    epl:subscribe(),
+    {ok, #state{}}.
+
+handle_call(Request, _From, _State) ->
+    exit({not_implemented, Request}).
+
+handle_cast({subscribe, Pid}, State = #state{subscribers = Subs}) ->
+    NewSubs = [Pid | Subs],
+    NewState = State#state{subscribers = NewSubs},
+    {noreply, NewState};
+handle_cast({unsubscribe, Pid}, State = #state{subscribers = Subs}) ->
+    NewSubs = lists:delete(Pid, Subs),
+    NewState = State#state{subscribers = NewSubs},
+    {noreply, NewState}.
+
+handle_info({data, _Key, _Proplist}, State = #state{subscribers = Subs}) ->
+    ETSCount = get_all_ets_count(),
+    ETSNodeInfo = {ETSCount},
+    JSON = epl_json:encode(ETSNodeInfo, <<"ets-node-info">>),
+    [Pid ! {data, JSON} || Pid <- Subs],
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%====================================================================
+%% Internals
+%%====================================================================
+
+get_all_ets_count() ->
+    AllETS = epl_tracer:command(fun ets:all/0, []),
+    length(AllETS).

--- a/src/epl_ets.erl
+++ b/src/epl_ets.erl
@@ -1,6 +1,6 @@
 %%%-------------------------------------------------------------------
-%% @doc epl_ets modules.
-%% It is a gen server listening to messages from epl main application.
+%% @doc epl_ets module.
+%% It is a gen_server listening to messages from epl main application.
 %% @end
 %%%-------------------------------------------------------------------
 
@@ -33,18 +33,30 @@
 %% API functions
 %%====================================================================
 
+%% @doc Stars epl_ets.
+-spec start_link() -> {ok, Pid :: pid()} |
+                      ignore |
+                      {reason, Reason :: term()}.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+%% @doc Add calling process to epl_ets subscribers.
+-spec subscribe() -> ok.
 subscribe() ->
     subscribe(self()).
 
+%% @doc Add provided `Pid` to epl_ets subscribers.
+-spec subscribe(Pid :: pid()) -> ok.
 subscribe(Pid) ->
     gen_server:cast(?MODULE, {subscribe, Pid}).
 
+%% @doc Remove calling process from epl_ets subscribers.
+-spec unsubscribe() -> ok.
 unsubscribe() ->
     unsubscribe(self()).
 
+%% @doc Remove provided `Pid` from epl_ets subscribers.
+-spec unsubscribe(Pid :: pid()) -> ok.
 unsubscribe(Pid) ->
     gen_server:cast(?MODULE, {unsubscribe, Pid}).
 

--- a/src/epl_ets_EPL.erl
+++ b/src/epl_ets_EPL.erl
@@ -1,0 +1,40 @@
+%%%-------------------------------------------------------------------
+%% @doc epl_ets_EPL module.
+%% It is a cowboy callback module which receives data from epl_ets and publishes
+%% them throught the websocket.
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(epl_ets_EPL).
+
+-behaviour(cowboy_websocket_handler).
+
+%% cowboy_websocket_handler callbacks
+-export([init/3,
+         websocket_init/3,
+         websocket_handle/3,
+         websocket_info/3,
+         websocket_terminate/3]).
+
+%%====================================================================
+%% cowboy_websocket_handler callbacks
+%%====================================================================
+
+init({tcp, http}, _Req, _Opts) ->
+    epl_ets:subscribe(),
+    {upgrade, protocol, cowboy_websocket}.
+
+websocket_init(_TransportName, Req, _Opts) ->
+    {ok, Req, undefined_state}.
+
+websocket_handle(Data, _Req, _State) ->
+    exit({not_implemented, Data}).
+
+websocket_info({data, Data}, Req, State) ->
+    {reply, {text, Data}, Req, State};
+websocket_info(Info, _Req, _State) ->
+    exit({not_implemented, Info}).
+
+websocket_terminate(_Reason, _Req, _State) ->
+    epl_ets:unsubscribe(),
+    ok.

--- a/src/epl_ets_EPL.erl
+++ b/src/epl_ets_EPL.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %% @doc epl_ets_EPL module.
-%% It is a cowboy callback module which receives data from epl_ets and publishes
-%% them throught the websocket.
+%% It is a cowboy websocket handler module which receives data from 
+%% epl_ets and sends them throught the websocket.
 %% @end
 %%%-------------------------------------------------------------------
 

--- a/src/epl_ets_sup.erl
+++ b/src/epl_ets_sup.erl
@@ -28,7 +28,12 @@ start_link() ->
 
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
-    {ok, { {one_for_all, 0, 1}, []} }.
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 1,
+                 period => 5},
+    ChildSpec = [#{id => epl_ets,
+                   start => {epl_ets, start_link, []}}],
+    {ok, SupFlags, ChildSpec}.
 
 %%====================================================================
 %% Internal functions

--- a/src/epl_ets_sup.erl
+++ b/src/epl_ets_sup.erl
@@ -33,7 +33,7 @@ init([]) ->
                  period => 5},
     ChildSpec = [#{id => epl_ets,
                    start => {epl_ets, start_link, []}}],
-    {ok, SupFlags, ChildSpec}.
+    {ok, {SupFlags, ChildSpec}}.
 
 %%====================================================================
 %% Internal functions


### PR DESCRIPTION
This PR allows to render basic ets information (number of ETS) from the observed node in web browser.
In order to build erlangpl and see how it works please follow this steps:
1. Build ets-node-info branch from [my fork of erlangpl repo](https://github.com/mkacper/erlangpl/tree/ets-node-info) with its deps.
2. Run erlangpl and start to observe a node.
3. Open ui/epl_ets/epl_ets.html in your favourtie browser (tested on Chrome).
4. Done!

Please let me know what do you think about this PR.